### PR TITLE
chore: bump to node v22

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Run install
         uses: borales/actions-yarn@v4
         with:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "prettier:fix": "prettier --write 'src/**/*.{js,jsx}'",
     "prepare": "husky install"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "lint-staged": {
     "*.{js,jsx}": [
       "eslint --ext js,jsx --fix",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated runtime requirement to Node.js 22.x in package metadata (engines.node).
  - Updated CI workflow to use Node.js 22.x for tests.
  - Installations on older Node versions may show engine warnings or be blocked by tooling; no changes to features, scripts, or dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->